### PR TITLE
only start timer if blink was enabled

### DIFF
--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -1249,8 +1249,8 @@ end
 function EMCO:enableBlink()
   self.blink = true
   if not self.blinkTimerID then
-    self.blinkTimerID = tempTimer(me.blinkTime, function()
-      me:doBlink()
+    self.blinkTimerID = tempTimer(self.blinkTime, function()
+      self.doBlink()
     end, true)
   end
 end

--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -431,9 +431,6 @@ function EMCO:new(cons, container)
   me.tabs = {}
   me.tabsToBlink = {}
   me.mc = {}
-  self.blinkTimerID = tempTimer(me.blinkTime, function()
-    me:doBlink()
-  end, true)
   me:reset()
   if me.allTab then
     me:setAllTabName(me.allTabName or me.consoles[1])
@@ -1251,11 +1248,20 @@ end
 --- Enables tab blinking when new information comes in to an inactive tab
 function EMCO:enableBlink()
   self.blink = true
+  if not self.blinkTimerID then
+    self.blinkTimerID = tempTimer(me.blinkTime, function()
+      me:doBlink()
+    end, true)
+  end
 end
 
 --- Disables tab blinking when new information comes in to an inactive tab
 function EMCO:disableBlink()
   self.blink = false
+  if self.blinkTimerID then
+    killTimer(self.blinkTimerID)
+    self.blinkTimerID = nil
+  end
 end
 
 --- Enables preserving the chat's background over the background of an incoming :append()

--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -431,6 +431,9 @@ function EMCO:new(cons, container)
   me.tabs = {}
   me.tabsToBlink = {}
   me.mc = {}
+  if me.blink then
+    me:enableBlink()
+  end
   me:reset()
   if me.allTab then
     me:setAllTabName(me.allTabName or me.consoles[1])
@@ -1250,7 +1253,7 @@ function EMCO:enableBlink()
   self.blink = true
   if not self.blinkTimerID then
     self.blinkTimerID = tempTimer(self.blinkTime, function()
-      self.doBlink()
+      self:doBlink()
     end, true)
   end
 end


### PR DESCRIPTION
I was using EMCO, but no console had blink enabled.
Still my debug would spam the anonymous timer.
Even more so because I have multiple ECMO.

With this change, the timer only starts after a console has blink enabled.
It will kill the timer if blink gets disabled as well. Stop the spam!