### PR TITLE
popupAssemble newline fix

### DIFF
--- a/src/resources/ftext.lua
+++ b/src/resources/ftext.lua
@@ -1261,7 +1261,7 @@ function TableMaker:popupAssemble()
       clearWindow(console)
     end
   end
-  local divWithNewLines = string.format("\n%s\n", self:createRowDivider())
+  local divWithNewLines = string.format("%s\n", self:createRowDivider())
   local header = self:makeHeader() .. "\n"
   local footer = string.format("%s%s%s\n", self.frameColor, string.rep(self.footCharacter, self:totalWidth()), self.colorReset)
   self:echo(header)


### PR DESCRIPTION
# insertPopup() newline issue
### OS: Windows 10
When trying to build a table using `insertPopup()` instead of regular text, I noticed it was creating an additional new line after each row.

## Description
The line in question is 
```
local divWithNewLines = string.format("\n%s\n", self:createRowDivider())
```

Which behaves differently for these two functions for reasons beyond the scope of my understanding. By removing the preceding `\n` from the above line in the `popupAssemble()` function I was able to fix it for my environment.

```
function TableMaker:popupAssemble()
  if self.autoClear then
    local console = self.autoEchoConsole
    if console and console ~= "main" then
      if type(console) == "table" then
        console = console.name
      end
      clearWindow(console)
    end
  end
  local divWithNewLines = string.format("\n%s\n", self:createRowDivider())
  local header = self:makeHeader() .. "\n"
  local footer = string.format("%s%s%s\n", self.frameColor, string.rep(self.footCharacter, self:totalWidth()), self.colorReset)
  self:echo(header)
  for _, row in ipairs(self.rows) do
    if _ ~= 1 and self.separateRows then
      self:echo(divWithNewLines)
    end
    self:echoRow(row)
  end
  self:echo(footer)
end
```
```
function TableMaker:textAssemble()
  local sheet = ""
  local rows = {}
  for _, row in ipairs(self.rows) do
    table.insert(rows, self:scanRow(row))
  end
  local divWithNewlines = string.format("\n%s\n", self:createRowDivider())
  local footer = string.format("%s%s%s", self.frameColor, string.rep(self.footCharacter, self:totalWidth()), self.colorReset)
  sheet = string.format("%s\n%s\n%s\n", self:makeHeader(), table.concat(rows, self.separateRows and divWithNewlines or "\n"), footer)
  if self.autoEcho then
    local console = self.autoEchoConsole or "main"
    if type(console) == "table" then
      console = console.name
    end
    if self.autoClear and console ~= "main" then
      clearWindow(console)
    end
    self:echo(sheet)
  end
  return sheet
end
```