### PR TITLE
EMCO: Add setters for activeTabCSS and inactiveTabCSS

### DIFF
--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -1465,6 +1465,20 @@ function EMCO:adjustTabBackgrounds()
   end
 end
 
+--- Sets the inactiveTabCSS
+-- @tparam string stylesheet the stylesheet to use for inactive tabs.
+function EMCO:setInactiveTabCSS(stylesheet)
+  self.inactiveTabCSS = stylesheet
+  self:adjustTabBackgrounds()
+end
+
+--- Sets the activeTabCSS
+-- @tparam string stylesheet the stylesheet to use for active tab.
+function EMCO:setActiveTabCSS(stylesheet)
+  self.activeTabCSS = stylesheet
+  self:adjustTabBackgrounds()
+end
+
 --- Sets the FG color for the active tab
 -- @param color Color string suitable for decho or hecho, or color name eg "purple", or table of colors {r,g,b}
 function EMCO:setActiveTabFGColor(color)


### PR DESCRIPTION
Add EMCO:setActiveTabCSS(stylesheet) and EMCO:setInactiveTabCSS(stylesheet) which will also apply the changes visually.

Fixes https://github.com/demonnic/MDK/issues/49