### PR TITLE
EMCO: Improved on tab click functionality

### DIFF
--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -627,7 +627,7 @@ function EMCO:removeTab(tabName)
     if self.allTab and self.allTabName then
       self:switchTab(self.allTabName)
     else
-      self:switchTab(self.consoles[1])
+      self:cycleTab()
     end
   end
   table.remove(self.consoles, table.index_of(self.consoles, tabName))
@@ -669,7 +669,7 @@ end
 function EMCO:switchTab(tabName)
   local oldTab = self.currentTab
   self.currentTab = tabName
-  if oldTab ~= tabName and oldTab ~= "" then
+  if oldTab ~= tabName and oldTab ~= "" and self.mc[oldTab] then
     self.mc[oldTab]:hide()
     self:adjustTabBackground(oldTab)
     self.tabs[oldTab]:echo(oldTab, self.inactiveTabFGColor)
@@ -706,6 +706,17 @@ function EMCO:cycleTab(reverse)
   self:switchTab(consoles[cycleIndex])
 end
 
+--- Handles the click on a tab, by default left click changes the tab, middle click removes it
+-- @param tabName string the name of the tab to show
+-- @param mouseClickEvent A table passed in when called by setClickCallback
+function EMCO:handleTabClick(tabName, onClickEvent)
+  if onClickEvent.button == "LeftButton" then
+    self:switchTab(tabName)
+  elseif onClickEvent.button == "MidButton" then
+    self:removeTab(tabName)
+  end
+end
+
 function EMCO:createComponentsForTab(tabName)
   local tab = Geyser.Label:new({name = string.format("%sTab%s", self.name, tabName)}, self.tabBox)
   if self.tabFont then
@@ -716,7 +727,7 @@ function EMCO:createComponentsForTab(tabName)
   tab:setItalics(self.tabItalics)
   tab:setBold(self.tabBold)
   tab:setUnderline(self.tabUnderline)
-  tab:setClickCallback(self.switchTab, self, tabName)
+  tab:setClickCallback(self.handleTabClick, self, tabName)
   self.tabs[tabName] = tab
   self:adjustTabBackground(tabName)
   tab:echo(tabName, self.inactiveTabFGColor)


### PR DESCRIPTION
This PR changes the on-click functionality when clicking on tabs in order to add a way to close them through UI.

Currently, any mouse click switches to the clicked tab.

The changes proposed here change that to the following:
LeftClick = Switch to tab
MiddleClick = Close tab
RightClick = No action