### PR TITLE
EMCO: Fix tab alignment

### DIFF
--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -660,8 +660,8 @@ function EMCO:addTab(tabName, position)
   else
     table.insert(self.consoles, position, tabName)
   end
-    self:reset()
-    self:switchTab(tabName)
+  self:reset()
+  self:switchTab(tabName)
 end
 
 --- Switches the active, visible tab of the EMCO to tabName

--- a/src/resources/emco.lua
+++ b/src/resources/emco.lua
@@ -657,11 +657,11 @@ function EMCO:addTab(tabName, position)
   end
   if position == 0 then
     table.insert(self.consoles, tabName)
-    self:createComponentsForTab(tabName)
   else
     table.insert(self.consoles, position, tabName)
-    self:reset()
   end
+    self:reset()
+    self:switchTab(tabName)
 end
 
 --- Switches the active, visible tab of the EMCO to tabName
@@ -1032,6 +1032,8 @@ function EMCO:reset()
     self:createComponentsForTab(tabName)
   end
 
+  self.tabBox:organize()
+
   local default = self.allTabName or self.consoles[1]
   self:switchTab(default)
 end
@@ -1041,7 +1043,7 @@ function EMCO:createContainers()
     x = 0,
     y = 0,
     width = "100%",
-    height = tostring(tonumber(self.tabHeight) + 2) .. "px",
+    height = tostring(tonumber(self.tabHeight)) .. "px",
     name = self.name .. "TabBoxLabel",
   }, self)
   self.tabBox = Geyser.HBox:new({x = 0, y = 0, width = "100%", height = "100%", name = self.name .. "TabBox"}, self.tabBoxLabel)


### PR DESCRIPTION
The first fix here is removing the 2 additional pixels on tab height. It stops the tab button labels from overlapping the miniconsole.

The second fix is fixing up the alignment when adding new tabs. The VBox acts weird if organize is not called (You can see in the before picture how the last tab is moved slightly to the right and slightly down)


Before:
![EMCO_before](https://github.com/demonnic/MDK/assets/16725570/4f2f7c0b-bf1b-4552-a4a5-7b8ebf0f06a2)

After:
![EMCO_after](https://github.com/demonnic/MDK/assets/16725570/b5e315cf-0f9a-4591-a218-473dc60128e1)
